### PR TITLE
ci: Maven download retries + job timeouts for reliability

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -25,10 +26,11 @@ jobs:
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - run: mvn install --settings .m2_settings.xml -DskipTests=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -B -V -q
+      - run: mvn install --settings .m2_settings.xml -DskipTests=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -B -V -q -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
         with:
@@ -40,7 +42,7 @@ jobs:
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - run: mvn verify --settings .m2_settings.xml -q
+      - run: mvn verify --settings .m2_settings.xml -q -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000
       - uses: actions/upload-artifact@v4
         with:
           name: builds
@@ -52,6 +54,7 @@ jobs:
   deploy-artifact-registry:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [ build, test ]
     steps:
       - uses: actions/checkout@v3
@@ -62,7 +65,7 @@ jobs:
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - run: mvn deploy --settings .m2_settings.xml -DskipTests=true -q
+      - run: mvn deploy --settings .m2_settings.xml -DskipTests=true -q -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000
 
   deploy-gcs:
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Why
Two recurring, non-deterministic CI failures across foreman repos that aren't caused by the code under test:

1. **Transient Maven resolution** — e.g. `Failed to execute goal maven-compiler-plugin:3.7.0:compile … could not be resolved`, a Central/registry hiccup that fails an otherwise-green build (recently tanked a clean foreman-apps PR run).
2. **Hung jobs** — a stuck test/server (this suite has multi-second waits and fake servers) can run to GitHub's **6-hour** default before the job is killed.

## What
On the shared `build` / `test` / `deploy-artifact-registry` jobs:
- Append Maven wagon resilience flags to every `mvn` invocation:
  `-Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000`
  → transient download failures retry instead of failing the job.
- `timeout-minutes: 45` → a hung job fails fast (the full suite runs in ~27 min, so 45 is safe headroom).

## Risk
Minimal and additive. **No behavior change on a healthy run** — retries only engage on a failed transfer; the timeout only triggers on a genuine hang. Applies to every repo that calls this reusable workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only, additive CI hardening with no application or deploy logic changes; healthy runs behave the same aside from longer per-transfer timeouts on failures.
> 
> **Overview**
> Hardens the reusable **Java** CI workflow (`.github/workflows/java.yml`) against flaky Maven downloads and runaway jobs.
> 
> **`build`**, **`test`**, and **`deploy-artifact-registry`** now set **`timeout-minutes: 45`** so stuck runs fail before GitHub’s default 6-hour cap. Every **`mvn install` / `verify` / `deploy`** step adds wagon HTTP resilience: **3 retries**, retries after request sent, and **60s** read timeout (`-Dmaven.wagon.http.retryHandler.count=3`, `requestSentEnabled=true`, `-Dmaven.wagon.rto=60000`).
> 
> **`deploy-gcs`** and **`publish-release`** are unchanged (no new timeout or Maven flags).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536b76d23e836d13736498e49212b65299a05ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->