### PR TITLE
ci: cache ~/.m2 and bump deprecated Node 20 actions

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -18,12 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: ${{ inputs.java }}
           distribution: temurin
-      - uses: google-github-actions/auth@v1
+          cache: maven
+      - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
       - run: mvn install --settings .m2_settings.xml -DskipTests=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -B -V -q -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000
@@ -32,14 +33,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: ${{ inputs.java }}
           distribution: temurin
-      - uses: google-github-actions/auth@v1
+          cache: maven
+      - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
       - run: mvn verify --settings .m2_settings.xml -q -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000
@@ -57,12 +59,13 @@ jobs:
     timeout-minutes: 45
     needs: [ build, test ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: ${{ inputs.java }}
           distribution: temurin
-      - uses: google-github-actions/auth@v1
+          cache: maven
+      - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
       - run: mvn deploy --settings .m2_settings.xml -DskipTests=true -q -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000
@@ -76,10 +79,10 @@ jobs:
         with:
           name: builds
           path: builds
-      - uses: google-github-actions/auth@v1
+      - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - uses: google-github-actions/upload-cloud-storage@v1
+      - uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: builds
           destination: ${{ inputs.gcs-bucket }}


### PR DESCRIPTION
## What

Two independent, low-risk CI improvements to the shared `java.yml`:

1. **Cache `~/.m2` across runs** — add `cache: maven` to every `setup-java` step (build, test, deploy). Dependencies stop being re-downloaded on every run. Action caches are scoped to the *calling* repo, so each consuming repo gets its own cache automatically.

2. **Bump the deprecated Node 20 actions** flagged in recent runs ("Node.js 20 actions are deprecated… forced to Node 24 by June 16th"):
   - `actions/checkout` v3 → v4
   - `actions/setup-java` v3 → v4
   - `google-github-actions/auth` v1 → v2
   - `google-github-actions/upload-cloud-storage` v1 → v2

   (`upload-artifact`/`download-artifact` are already v4.)

## Why

Companion to foreman-apps#775, which routes Maven resolution through an Artifact Registry virtual repo to stop the intermittent Maven Central `Connection reset` build failures. **This PR is independent of that infra** — it's a pure build-time speedup + deprecation cleanup and is safe to merge on its own.

## Notes

- **Snapshot freshness:** caching is fully safe for release + third-party artifacts (immutable). For internal `mn.foreman` SNAPSHOTs, the consuming repos build their whole reactor in-process (so their own modules are always rebuilt fresh), and Maven's default daily snapshot update-policy re-checks any cross-repo snapshots — so stale snapshots aren't a practical concern. If it ever bites, switch to `actions/cache` with a pre-build prune of `~/.m2/repository/mn/foreman`.
- **Deliberately *not* in this PR:** centralizing `.m2_settings.xml` into this workflow. Changing the shared settings to point at the new virtual repo would flip *every* consuming repo at once, before the Artifact Registry infra + the approach are validated. Recommend doing that as a follow-up once foreman-apps#775 is proven green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no application or security logic; main caveat is cached SNAPSHOT behavior, which the PR author notes is acceptable for current usage.
> 
> **Overview**
> Updates the reusable **`.github/workflows/java.yml`** workflow with faster Maven CI and newer GitHub Actions.
> 
> **Maven caching:** Every job that runs `setup-java` (`build`, `test`, `deploy-artifact-registry`) now sets **`cache: maven`** so `~/.m2` is restored between runs instead of re-downloading dependencies each time.
> 
> **Action upgrades (Node 20 deprecation cleanup):** `actions/checkout` and `actions/setup-java` move **v3 → v4** where used; `google-github-actions/auth` **v1 → v2** in all jobs that authenticate; `deploy-gcs` also bumps **`upload-cloud-storage` v1 → v2**. Artifact upload/download steps were already on v4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 590fa6ec8e46fffc1ff3f0785f8c547d5527874d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->