### PR TITLE
ci: raise build/test timeout 45→90m for Artifact Registry warm-up

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -31,7 +31,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,7 +56,7 @@ jobs:
   deploy-artifact-registry:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     needs: [ build, test ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Companion to foreman-apps#775. Pointing Maven resolution at the Artifact Registry `maven-central` proxy means the first builds must warm an empty cache (fetch every public dependency from Central through AR), which exceeds 45m on the large reactor and the job gets auto-cancelled.

Raise the ceiling to 90m so the one-time warm-up completes. Steady-state runs (warm proxy + the `cache: maven` added in #5) finish well under this — the limit can be tuned back down once warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only timeout increases with no application or deployment logic changes; main effect is longer-running jobs if builds hang.
> 
> **Overview**
> Raises the GitHub Actions job timeout from **45 to 90 minutes** on the reusable Java workflow’s **`build`**, **`test`**, and **`deploy-artifact-registry`** jobs in `.github/workflows/java.yml`.
> 
> This is meant to cover the first Maven runs after resolving dependencies through the Artifact Registry `maven-central` proxy (cold cache / warm-up), which were hitting the old limit and getting cancelled. No Maven steps, caching, or deploy logic change—only the per-job time ceiling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 459120b67ffb803b0d53a2f9753270e54933b334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->