### PR TITLE
ci: tune build/test timeout 90→75m (warm-up done)

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -31,7 +31,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,7 +56,7 @@ jobs:
   deploy-artifact-registry:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 75
     needs: [ build, test ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Follow-up to #6. The 90m ceiling was temporary headroom for the one-time Artifact Registry cold-cache warm-up (foreman-apps#775), now complete — the `maven-central` proxy is warm and `cache: maven` restores `~/.m2` across runs.

**Evidence the proxy/cache work:** in the latest warm run, the build job finished in **<2 min** and the test job did **zero remote downloads** (cache hit).

**Why 75m and not lower:** the test job is dominated by the socket integration suite and varies with runner speed — a recent warm run took **47 min** (vs the usual ~22–28). 75m clears that outlier with margin while removing the warm-up-only headroom. (The original 45m would have been exceeded by that 47m run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes CI job timeouts; no application, auth, or deployment logic is modified.
> 
> **Overview**
> Lowers the GitHub Actions job timeout from **90** to **75** minutes for the **`build`**, **`test`**, and **`deploy-artifact-registry`** jobs in `.github/workflows/java.yml`.
> 
> This removes temporary headroom that was added for Artifact Registry / Maven cache warm-up; warm runs are much faster now, while **75m** still covers slow integration-test outliers on `ubuntu-latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f7fbd6cd8f8410a7a9ee5f336089eee5eaed3dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->