### PR TITLE
ci: revert proxy-era timeout (75→45) + tune Maven for Central resets

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -27,11 +27,11 @@ jobs:
       - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - run: mvn install --settings .m2_settings.xml -DskipTests=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -B -V -q -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000
+      - run: mvn install --settings .m2_settings.xml -DskipTests=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -B -V -q -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000 -Dmaven.wagon.http.pool=false
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,7 +44,7 @@ jobs:
       - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - run: mvn verify --settings .m2_settings.xml -q -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000
+      - run: mvn verify --settings .m2_settings.xml -q -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000 -Dmaven.wagon.http.pool=false
       - uses: actions/upload-artifact@v4
         with:
           name: builds
@@ -56,7 +56,7 @@ jobs:
   deploy-artifact-registry:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 45
     needs: [ build, test ]
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
       - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - run: mvn deploy --settings .m2_settings.xml -DskipTests=true -q -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000
+      - run: mvn deploy --settings .m2_settings.xml -DskipTests=true -q -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.rto=60000 -Dmaven.wagon.http.pool=false
 
   deploy-gcs:
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Companion to foreman-apps#776 (dropping the Artifact Registry proxy).

- **timeout 75→45**: the bumped ceiling existed only for the proxy's one-time cold-cache warm-up; without the proxy, test is back to ~22–28 min, so 45 (the original) is comfortable.
- **Flake mitigation** (replaces the proxy's role for the rare build-job Central `Connection reset`): `retryHandler.count` 3→5, plus `maven.wagon.http.pool=false` so stale pooled keep-alive connections aren't reused (the classic cause of mid-transfer resets). With `cache: maven` warm, the extra per-request connection cost is small.

Kept from earlier work: `cache: maven` and the Node-24 action bumps (both unrelated to the proxy and beneficial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub Actions workflow and Maven CLI flags; no runtime application or security logic changes.
> 
> **Overview**
> Reverts Java workflow job timeouts from **75 to 45 minutes** on `build`, `test`, and `deploy-artifact-registry`, matching pre–Artifact Registry proxy expectations now that runs are ~22–28 minutes again.
> 
> **Maven HTTP resilience** on every `mvn` step (`install`, `verify`, `deploy`): bumps `maven.wagon.http.retryHandler.count` from **3 to 5** and sets **`maven.wagon.http.pool=false`** to avoid reusing stale keep-alive connections that can cause Central `Connection reset` flakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a26676b9bc5f2859bef45e8928bbb78bc6cbd197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->